### PR TITLE
Combining RowSet and chunks sometimes there are rowsets as well as chunks

### DIFF
--- a/Snowflake.Client.Tests/IntegrationTests/IntegrationTestBase.cs
+++ b/Snowflake.Client.Tests/IntegrationTests/IntegrationTestBase.cs
@@ -14,7 +14,17 @@ namespace Snowflake.Client.Tests.IntegrationTests
             var testParameters = JsonSerializer.Deserialize<TestConfiguration>(configJson, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
             var connectionInfo = testParameters.Connection;
 
-            _snowflakeClient = new SnowflakeClient(connectionInfo.User, connectionInfo.Password, connectionInfo.Account, connectionInfo.Region);
+            _snowflakeClient = new SnowflakeClient(new Model.AuthInfo
+            {
+                User = connectionInfo.User, 
+                Password = connectionInfo.Password, 
+                Account = connectionInfo.Account, 
+                Region = connectionInfo.Region
+            },
+            new Model.SessionInfo
+            {
+                Warehouse = connectionInfo.Warehouse
+            });
         }
     }
 }

--- a/Snowflake.Client.Tests/IntegrationTests/SnowflakeChunksDownloaderTest.cs
+++ b/Snowflake.Client.Tests/IntegrationTests/SnowflakeChunksDownloaderTest.cs
@@ -29,6 +29,16 @@ namespace Snowflake.Client.Tests.IntegrationTests
 
             Assert.AreEqual(selectCount, records.Count);
         }
+
+        [Test]
+        public async Task QueryAndMap_ResponseWithChunks_AndRowset()
+        {
+            var selectCount = 1300;
+            var result = await _snowflakeClient.QueryAsync<Supplier>($"select top {selectCount} * from SNOWFLAKE_SAMPLE_DATA.TPCH_SF1000.SUPPLIER;");
+            var records = result.ToList();
+
+            Assert.AreEqual(selectCount, records.Count);
+        }
     }
 
     internal class Supplier

--- a/Snowflake.Client/Helpers/SnowflakeUtils.cs
+++ b/Snowflake.Client/Helpers/SnowflakeUtils.cs
@@ -78,6 +78,7 @@ namespace Snowflake.Client.Helpers
                 { "eu-west-1", "" },
                 { "eu-west-2", "aws" },
                 { "eu-central-1", "" },
+                { "eu-north-1", "aws" },
                 { "ap-northeast-1", "aws" },
                 { "ap-south-1", "aws" },
                 { "ap-southeast-1", "" },

--- a/Snowflake.Client/SnowflakeClient.cs
+++ b/Snowflake.Client/SnowflakeClient.cs
@@ -172,12 +172,12 @@ namespace Snowflake.Client
 
             if (response.Data.Chunks != null && response.Data.Chunks.Count > 0)
             {
-                rowSet = await ChunksDownloader.DownloadAndParseChunksAsync(new ChunksDownloadInfo()
+                rowSet.AddRange(await ChunksDownloader.DownloadAndParseChunksAsync(new ChunksDownloadInfo()
                 {
                     ChunkHeaders = response.Data.ChunkHeaders,
                     Chunks = response.Data.Chunks,
                     Qrmk = response.Data.Qrmk
-                }, ct);
+                }, ct));
             }
 
             var result = SnowflakeDataMapper.MapTo<T>(response.Data.RowType, rowSet);


### PR DESCRIPTION
I found a weird issue today as not all the rows I selected from snowflake was returned. When I ran the query directly in the snowflake worksheet everything was fine. It seemed like it was missing half a chunk or so. I was able to reproduce the error as seen below from a debug session:

![Snowflake-client-rowset-issue](https://user-images.githubusercontent.com/2152410/193622617-24f025d2-124f-43c1-81bc-fe96f2656a82.jpg)

It seems that sometimes not all the data is contained within the chunks, some rows are returned by the initial response as part of RowSet. To get all the rows I had to combine the data from the chunks along with the data inside RowSet (see the blue dots). My region "eu-north-1" was also missing in `GetCloudTagByRegion` and I could not get the integration tests to run without adding a warehouse in `IntegrationTestBase`.

Note: It seems that on subsequent requests all the rows are within chunks, but you can try and change the `selectCount` in the tests to provoke it. 

Let me know what you think!