### PR TITLE
Add Oauth authentication for Azure AD SSO

### DIFF
--- a/Snowflake.Client.Tests/Models/TestConfiguration.cs
+++ b/Snowflake.Client.Tests/Models/TestConfiguration.cs
@@ -3,5 +3,10 @@
     public class TestConfiguration
     {
         public SnowflakeConnectionInfo Connection { get; set; }
+        public string AdClientId { get; set; }
+        public string AdClientSecret { get; set; }
+        public string AdServicePrincipalObjectId { get; set; }
+        public string AdTenantId { get; set; }
+        public string AdScope { get; set; }
     }
 }

--- a/Snowflake.Client.Tests/Snowflake.Client.Tests.csproj
+++ b/Snowflake.Client.Tests/Snowflake.Client.Tests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.53.0" />
+    <PackageReference Include="moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />

--- a/Snowflake.Client.Tests/UnitTests/AzureAdAuthInfoTest.cs
+++ b/Snowflake.Client.Tests/UnitTests/AzureAdAuthInfoTest.cs
@@ -1,0 +1,34 @@
+using System;
+using NUnit.Framework;
+using Snowflake.Client.Tests.Models;
+using Snowflake.Client.Model;
+using System.IO;
+using System.Text.Json;
+
+namespace Snowflake.Client.Tests.IntegrationTests
+{
+    [TestFixture]
+    public class AzureAdAuthInfoTests
+    {
+        protected readonly AzureAdAuthInfo _azureAdAuthInfo;
+
+        public AzureAdAuthInfoTests()
+        {
+            var configJson = File.ReadAllText("testconfig.json");
+            var testParameters = JsonSerializer.Deserialize<TestConfiguration>(configJson, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+            var connectionInfo = testParameters.Connection;
+
+            _azureAdAuthInfo = new AzureAdAuthInfo(
+                testParameters.AdClientId,
+                testParameters.AdClientSecret,
+                testParameters.AdServicePrincipalObjectId,
+                testParameters.AdTenantId,
+                testParameters.AdScope,
+                connectionInfo.Region,
+                connectionInfo.Account,
+                connectionInfo.User,
+                connectionInfo.Host,
+                connectionInfo.Role);
+        }
+    }
+}

--- a/Snowflake.Client.Tests/UnitTests/AzureAdTokenProviderTest.cs
+++ b/Snowflake.Client.Tests/UnitTests/AzureAdTokenProviderTest.cs
@@ -1,0 +1,32 @@
+using Microsoft.Identity.Client;
+using Moq;
+using NUnit.Framework;
+using Snowflake.Client;
+using Snowflake.Client.Model;
+using Snowflake.Client.Tests.IntegrationTests;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Snowflake.Client.Tests
+{
+    public class AzureAdTokenProviderTests : AzureAdAuthInfoTests
+    {
+        [Test]
+        public async Task GetAzureAdAccessTokenAsync_ReturnsAccessToken()
+        {
+            var expectedAccessToken = "accessToken";
+            var mockTokenProvider = new Mock<IAzureAdTokenProvider>();
+
+            mockTokenProvider
+            .Setup(provider => provider.GetAzureAdAccessTokenAsync(It.IsAny<AzureAdAuthInfo>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedAccessToken);
+
+            // Act
+            string actualAccessToken = await mockTokenProvider.Object.GetAzureAdAccessTokenAsync(_azureAdAuthInfo);
+
+            // Assert
+            Assert.AreEqual(expectedAccessToken, actualAccessToken);
+        }
+    }
+}

--- a/Snowflake.Client/AzureAdTokenProvider.cs
+++ b/Snowflake.Client/AzureAdTokenProvider.cs
@@ -1,0 +1,41 @@
+using Microsoft.Identity.Client;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Snowflake.Client.Model;
+
+namespace Snowflake.Client 
+{
+    public class AzureAdTokenProvider : IAzureAdTokenProvider
+    {
+        public async Task<string> GetAzureAdAccessTokenAsync(AzureAdAuthInfo authInfo, CancellationToken ct = default)
+        {
+            try
+            {
+                if (authInfo.ClientId == null || authInfo.ClientSecret == null || authInfo.ServicePrincipalObjectId == null || authInfo.TenantId == null || authInfo.Scope == null)
+                {
+                    throw new SnowflakeException("Error: One or more required environment variables are missing.", 400);
+                }
+
+                return await GetAccessTokenAsync(authInfo.ClientId, authInfo.ClientSecret, authInfo.ServicePrincipalObjectId, authInfo.TenantId, authInfo.Scope);
+            }
+            catch (Exception ex)
+            {
+                throw new SnowflakeException($"Failed getting the Azure Token. Message: {ex.Message}", ex);
+            }
+        }
+
+        private async Task<string> GetAccessTokenAsync(string clientId, string clientSecret, string servicePrincipalObjectId, string tenantId, string scope)
+        {
+            IConfidentialClientApplication app = ConfidentialClientApplicationBuilder.Create(clientId)
+                .WithClientSecret(clientSecret)
+                .WithAuthority(new Uri($"https://login.microsoftonline.com/{tenantId}/"))
+                .Build();
+
+            var scopes = new[] { scope };
+
+            AuthenticationResult result = await app.AcquireTokenForClient(scopes).ExecuteAsync();
+            return result.AccessToken;
+        }
+    }
+}

--- a/Snowflake.Client/IAzureAdTokenProvider.cs
+++ b/Snowflake.Client/IAzureAdTokenProvider.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Snowflake.Client.Model;
+
+namespace Snowflake.Client
+{
+    public interface IAzureAdTokenProvider
+        {
+            Task<string> GetAzureAdAccessTokenAsync(AzureAdAuthInfo authInfo, CancellationToken ct = default);
+    }
+}

--- a/Snowflake.Client/Model/AuthInfo.cs
+++ b/Snowflake.Client/Model/AuthInfo.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Snowflake Authentication information.
     /// </summary>
-    public class AuthInfo
+    public class AuthInfo : IAuthInfo
     {
         /// <summary>
         /// Your Snowflake account name

--- a/Snowflake.Client/Model/AzureAdAuthInfo.cs
+++ b/Snowflake.Client/Model/AzureAdAuthInfo.cs
@@ -1,0 +1,29 @@
+namespace Snowflake.Client.Model
+{
+    public class AzureAdAuthInfo : AuthInfo
+    {
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+        public string ServicePrincipalObjectId { get; set; }
+        public string TenantId { get; set; }
+        public string Scope { get; set; }
+        public string Host {get; set; }
+        public string Role {get; set; }
+
+
+        public AzureAdAuthInfo(string clientId, string clientSecret, string servicePrincipalObjectId, string tenantId, string scope, string region, string account, string user, string host, string role)
+            : base(user, account, region)
+        {
+            ClientId = clientId;
+            ClientSecret = clientSecret;
+            ServicePrincipalObjectId = servicePrincipalObjectId;
+            TenantId = tenantId;
+            Scope = scope;
+            Region = region;
+            Account = account;
+            User = user;
+            Host = host;
+            Role = role;
+        }
+    }
+}

--- a/Snowflake.Client/Model/IAuthInfo.cs
+++ b/Snowflake.Client/Model/IAuthInfo.cs
@@ -1,0 +1,11 @@
+namespace Snowflake.Client.Model
+{
+    public interface IAuthInfo
+    {
+        string Account { get; set; }
+        string User { get; set; }
+        string Region { get; set; }
+
+        string ToString();
+    }
+}

--- a/Snowflake.Client/RequestBuilder.cs
+++ b/Snowflake.Client/RequestBuilder.cs
@@ -51,19 +51,27 @@ namespace Snowflake.Client
             _masterToken = null;
         }
 
-        internal HttpRequestMessage BuildLoginRequest(AuthInfo authInfo, SessionInfo sessionInfo)
+        internal HttpRequestMessage BuildLoginRequest(AuthInfo authInfo, SessionInfo sessionInfo, String azureAdAccessToken = null)
         {
             var requestUri = BuildLoginUrl(sessionInfo);
+            var data = new LoginRequestData();
+            
+            if (authInfo is AzureAdAuthInfo azureAdAuthInfo) {
+                data = new LoginRequestData() {
+                    Authenticator = "OAUTH",
+                    Token = azureAdAccessToken,
+                };
+            } else {
+                data = new LoginRequestData() {
+                    Password = authInfo.Password,
+                };
+            }
 
-            var data = new LoginRequestData()
-            {
-                LoginName = authInfo.User,
-                Password = authInfo.Password,
-                AccountName = authInfo.Account,
-                ClientAppId = _clientInfo.DriverName,
-                ClientAppVersion = _clientInfo.DriverVersion,
-                ClientEnvironment = _clientInfo.Environment
-            };
+            data.LoginName = authInfo.User;
+            data.AccountName = authInfo.Account;
+            data.ClientAppId = _clientInfo.DriverName;
+            data.ClientAppVersion = _clientInfo.DriverVersion;
+            data.ClientEnvironment = _clientInfo.Environment;
 
             var requestBody = new LoginRequest() { Data = data };
             var jsonBody = JsonSerializer.Serialize(requestBody, _jsonSerializerOptions);

--- a/Snowflake.Client/Snowflake.Client.csproj
+++ b/Snowflake.Client/Snowflake.Client.csproj
@@ -32,4 +32,8 @@ Provides straightforward and efficient way to execute SQL queries in Snowflake a
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.53.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Related to: [](https://github.com/fixer-m/snowflake-db-net-client/issues/28)

Not sure if the design pattern is the best. After getting to a certain point I did wish I had separated some stuff away from SnowflakeClient.cs into some sort of Authenticator class. Tests just mock the AzureAd response and make sure the new AzureAdAuthInfo can be instantiated. Integration tests are hard as it requires the specific setup.