### PR TITLE
Deserialization efficiency improvements

### DIFF
--- a/Snowflake.Client.Benchmarks/HexUtilsBenchmarks.cs
+++ b/Snowflake.Client.Benchmarks/HexUtilsBenchmarks.cs
@@ -10,14 +10,14 @@ public class HexUtilsBenchmarks
     static readonly string __hexCharsLong = GenerateRandomHex(2_000_000);
 
     [Benchmark]
-    public void HexToBytes_Short()
+    public void HexToBase64_Short()
     {
         var sb = new StringBuilder();
         HexUtils.HexToBase64("0a0b0c", sb);
     }
 
     [Benchmark]
-    public void HexToBytes_Long()
+    public void HexToBase64_Long()
     {
         var sb = new StringBuilder();
         HexUtils.HexToBase64(__hexCharsLong, sb);

--- a/Snowflake.Client.Benchmarks/HexUtilsBenchmarks.cs
+++ b/Snowflake.Client.Benchmarks/HexUtilsBenchmarks.cs
@@ -1,0 +1,38 @@
+﻿using System.Text;
+using BenchmarkDotNet.Attributes;
+using Snowflake.Client.Helpers;
+
+namespace Snowflake.Client.Benchmarks;
+
+[MemoryDiagnoser]
+public class HexUtilsBenchmarks
+{
+    static readonly string __hexCharsLong = GenerateRandomHex(2_000_000);
+
+    [Benchmark]
+    public void HexToBytes_Short()
+    {
+        var sb = new StringBuilder();
+        HexUtils.HexToBase64("0a0b0c", sb);
+    }
+
+    [Benchmark]
+    public void HexToBytes_Long()
+    {
+        var sb = new StringBuilder();
+        HexUtils.HexToBase64(__hexCharsLong, sb);
+    }
+
+    private static string GenerateRandomHex(int length)
+    {
+        Random rng = new(123);
+
+        StringBuilder sb = new(length);
+        for(int i = 0; i < length; i++)
+        {
+            sb.Append(rng.Next(0, 16).ToString("X"));
+        }
+
+        return sb.ToString();
+    }
+}

--- a/Snowflake.Client.Benchmarks/Program.cs
+++ b/Snowflake.Client.Benchmarks/Program.cs
@@ -1,0 +1,9 @@
+﻿using BenchmarkDotNet.Running;
+using Snowflake.Client.Benchmarks;
+
+var switcher = new BenchmarkSwitcher(new[] {
+            typeof(SnowflakeDataMapperBenchmarks),
+            typeof(HexUtilsBenchmarks)
+        });
+
+switcher.Run(args);

--- a/Snowflake.Client.Benchmarks/Snowflake.Client.Benchmarks.csproj
+++ b/Snowflake.Client.Benchmarks/Snowflake.Client.Benchmarks.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Snowflake.Client.Benchmarks/Snowflake.Client.Benchmarks.csproj
+++ b/Snowflake.Client.Benchmarks/Snowflake.Client.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Snowflake.Client\Snowflake.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Snowflake.Client.Benchmarks/SnowflakeDataMapperBenchmarks.cs
+++ b/Snowflake.Client.Benchmarks/SnowflakeDataMapperBenchmarks.cs
@@ -1,0 +1,101 @@
+﻿using BenchmarkDotNet.Attributes;
+using Snowflake.Client.Json;
+
+namespace Snowflake.Client.Benchmarks;
+
+[MemoryDiagnoser]
+public class SnowflakeDataMapperBenchmarks
+{
+    readonly QueryExecResponseData _responseSample;
+    readonly List<List<string>> _objectRowset;
+
+    public SnowflakeDataMapperBenchmarks()
+    {
+        _responseSample = GetFakeResponse();
+        _objectRowset = new List<List<string>>() { _responseSample.RowSet[0] };
+    }
+
+    [Benchmark]
+    public void ResponseWithValues_MapTo_CustomClass()
+    {
+        SnowflakeDataMapper.MapTo<CustomClass>(_responseSample.RowType, _objectRowset);
+    }
+
+    private static QueryExecResponseData GetFakeResponse()
+    {
+        var response = new QueryExecResponseData() { RowType = new List<ColumnDescription>(), RowSet = new List<List<string>>() };
+
+        response.RowType.Add(new ColumnDescription() { Name = "StringProperty", Type = "text" });
+        response.RowType.Add(new ColumnDescription() { Name = "BoolProperty", Type = "boolean" });
+        response.RowType.Add(new ColumnDescription() { Name = "IntProperty", Type = "fixed" });
+        response.RowType.Add(new ColumnDescription() { Name = "FloatProperty", Type = "real" });
+        response.RowType.Add(new ColumnDescription() { Name = "DecimalProperty", Type = "real" });
+        response.RowType.Add(new ColumnDescription() { Name = "DateTimeProperty", Type = "timestamp_ntz" });
+        response.RowType.Add(new ColumnDescription() { Name = "DateTimeOffsetProperty", Type = "timestamp_ltz" });
+        response.RowType.Add(new ColumnDescription() { Name = "GuidProperty", Type = "text" });
+        response.RowType.Add(new ColumnDescription() { Name = "ByteArrayProperty", Type = "binary" });
+
+        response.RowSet.Add(new List<string>()
+            {
+                "Sometext",
+                "true",
+                "7",
+                "27.6",
+                "19.239834",
+                "1600000000.000000000",
+                "1600000000.000000000",
+                "e7412bbf-88ee-4149-b341-101e0f72ec7c",
+                "0080ff"
+            });
+
+        response.RowSet.Add(new List<string>()
+            {
+                "null",
+                "null",
+                "null",
+                "null",
+                "null",
+                "null",
+                "null",
+                "null",
+                "null"
+            });
+
+
+        response.RowSet.Add(new List<string>()
+            {
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+            });
+
+        return response;
+    }
+
+    private class CustomClass
+    {
+        public string StringProperty { get; set; }
+
+        public bool BoolProperty { get; set; }
+
+        public int IntProperty { get; set; }
+
+        public float FloatProperty { get; set; }
+
+        public decimal DecimalProperty { get; set; }
+
+        public DateTime DateTimeProperty { get; set; }
+
+        public DateTimeOffset DateTimeOffsetProperty { get; set; }
+
+        public Guid GuidProperty { get; set; }
+
+        public byte[] ByteArrayProperty { get; set; }
+    }
+}

--- a/Snowflake.Client.Benchmarks/SnowflakeDataMapperBenchmarks.cs
+++ b/Snowflake.Client.Benchmarks/SnowflakeDataMapperBenchmarks.cs
@@ -18,7 +18,14 @@ public class SnowflakeDataMapperBenchmarks
     [Benchmark]
     public void ResponseWithValues_MapTo_CustomClass()
     {
-        SnowflakeDataMapper.MapTo<CustomClass>(_responseSample.RowType, _objectRowset);
+        var enumerable = SnowflakeDataMapper.MapTo<CustomClass>(_responseSample.RowType, _objectRowset);
+
+        // Enumerate the result to actually execute the code inside the iterator method.
+        string stringValue;
+        foreach(var result in enumerable)
+        {
+            stringValue = result.StringProperty;
+        }
     }
 
     private static QueryExecResponseData GetFakeResponse()
@@ -35,20 +42,25 @@ public class SnowflakeDataMapperBenchmarks
         response.RowType.Add(new ColumnDescription() { Name = "GuidProperty", Type = "text" });
         response.RowType.Add(new ColumnDescription() { Name = "ByteArrayProperty", Type = "binary" });
 
-        response.RowSet.Add(new List<string>()
-            {
-                "Sometext",
-                "true",
-                "7",
-                "27.6",
-                "19.239834",
-                "1600000000.000000000",
-                "1600000000.000000000",
-                "e7412bbf-88ee-4149-b341-101e0f72ec7c",
-                "0080ff"
-            });
+        for(int i=0; i < 10; i++)
+        { 
+            response.RowSet.Add(
+                new List<string>()
+                {
+                    "Sometext",
+                    "true",
+                    "7",
+                    "27.6",
+                    "19.239834",
+                    "1600000000.000000000",
+                    "1600000000.000000000",
+                    "e7412bbf-88ee-4149-b341-101e0f72ec7c",
+                    "0080ff0a0b0c0d0e0f"
+                });
+        }
 
-        response.RowSet.Add(new List<string>()
+        response.RowSet.Add(
+            new List<string>()
             {
                 "null",
                 "null",
@@ -61,8 +73,8 @@ public class SnowflakeDataMapperBenchmarks
                 "null"
             });
 
-
-        response.RowSet.Add(new List<string>()
+        response.RowSet.Add(
+            new List<string>()
             {
                 null,
                 null,
@@ -78,7 +90,7 @@ public class SnowflakeDataMapperBenchmarks
         return response;
     }
 
-    private class CustomClass
+    public class CustomClass
     {
         public string StringProperty { get; set; }
 

--- a/Snowflake.Client.Benchmarks/SnowflakeDataMapperBenchmarks.cs
+++ b/Snowflake.Client.Benchmarks/SnowflakeDataMapperBenchmarks.cs
@@ -7,25 +7,25 @@ namespace Snowflake.Client.Benchmarks;
 public class SnowflakeDataMapperBenchmarks
 {
     readonly QueryExecResponseData _responseSample;
-    readonly List<List<string>> _objectRowset;
 
     public SnowflakeDataMapperBenchmarks()
     {
         _responseSample = GetFakeResponse();
-        _objectRowset = new List<List<string>>() { _responseSample.RowSet[0] };
     }
 
     [Benchmark]
-    public void ResponseWithValues_MapTo_CustomClass()
+    public int ResponseWithValues_MapTo_CustomClass()
     {
-        var enumerable = SnowflakeDataMapper.MapTo<CustomClass>(_responseSample.RowType, _objectRowset);
+        var enumerable = SnowflakeDataMapper.MapTo<CustomClass>(_responseSample.RowType, _responseSample.RowSet);
 
         // Enumerate the result to actually execute the code inside the iterator method.
-        string stringValue;
+        int totalLen = 0;
         foreach(var result in enumerable)
         {
-            stringValue = result.StringProperty;
+            totalLen += result.StringProperty?.Length ?? 0;
         }
+
+        return totalLen;
     }
 
     private static QueryExecResponseData GetFakeResponse()
@@ -42,7 +42,7 @@ public class SnowflakeDataMapperBenchmarks
         response.RowType.Add(new ColumnDescription() { Name = "GuidProperty", Type = "text" });
         response.RowType.Add(new ColumnDescription() { Name = "ByteArrayProperty", Type = "binary" });
 
-        for(int i=0; i < 10; i++)
+        for(int i=0; i < 100; i++)
         { 
             response.RowSet.Add(
                 new List<string>()
@@ -58,34 +58,6 @@ public class SnowflakeDataMapperBenchmarks
                     "0080ff0a0b0c0d0e0f"
                 });
         }
-
-        response.RowSet.Add(
-            new List<string>()
-            {
-                "null",
-                "null",
-                "null",
-                "null",
-                "null",
-                "null",
-                "null",
-                "null",
-                "null"
-            });
-
-        response.RowSet.Add(
-            new List<string>()
-            {
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            });
 
         return response;
     }

--- a/Snowflake.Client.Tests/UnitTests/HexUtilsTests.cs
+++ b/Snowflake.Client.Tests/UnitTests/HexUtilsTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Text;
+using NUnit.Framework;
+using Snowflake.Client.Helpers;
+
+namespace Snowflake.Client.Tests.UnitTests
+{
+    [TestFixture]
+    public class HexUtilsTests
+    {
+        [Test]
+        [TestCase("0080ff", 0, 128, 255)]
+        [TestCase("0a0b0c", 10, 11, 12)]
+        public void ConvertHexToBytes(string hex, byte b1, byte b2, byte b3)
+        {
+            var expectedBytes = new byte[] { b1, b2, b3 };
+            string expectedBase64 = Convert.ToBase64String(expectedBytes);
+
+            var sb = new StringBuilder();
+            HexUtils.HexToBase64(hex, sb);
+
+            Assert.AreEqual(expectedBase64, sb.ToString());
+        }
+    }
+}

--- a/Snowflake.Client.Tests/UnitTests/HexUtilsTests.cs
+++ b/Snowflake.Client.Tests/UnitTests/HexUtilsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Text;
 using NUnit.Framework;
 using Snowflake.Client.Helpers;
@@ -21,5 +22,31 @@ namespace Snowflake.Client.Tests.UnitTests
 
             Assert.AreEqual(expectedBase64, sb.ToString());
         }
+
+        [Test]
+        [TestCaseSource("TestCases")]
+        public void ConvertHexToBytes_VaryingLengths(string hex, byte[] expectedBytes)
+        {
+            string expectedBase64 = Convert.ToBase64String(expectedBytes);
+
+            var sb = new StringBuilder();
+            HexUtils.HexToBase64(hex, sb);
+
+            Assert.AreEqual(expectedBase64, sb.ToString());
+        }
+
+        public static IEnumerable TestCases
+        {
+            get
+            {
+                yield return new TestCaseData("00", new byte[] { 0x00 });
+                yield return new TestCaseData("0080", new byte[] { 0x00, 0x80 });
+                yield return new TestCaseData("0080ff", new byte[] { 0x00, 0x80, 0xff });
+                yield return new TestCaseData("0a0b0c0d", new byte[] { 0x0a, 0x0b, 0x0c, 0x0d });
+                yield return new TestCaseData("0a0b0c0d0e", new byte[] { 0x0a, 0x0b, 0x0c, 0x0d, 0x0e });
+                yield return new TestCaseData("0a0b0c0d0e0f", new byte[] { 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f });
+            }
+        }
+
     }
 }

--- a/Snowflake.Client.Tests/UnitTests/SnowflakeTypesConverterTest.cs
+++ b/Snowflake.Client.Tests/UnitTests/SnowflakeTypesConverterTest.cs
@@ -80,16 +80,5 @@ namespace Snowflake.Client.Tests.UnitTests
             var hexResult = SnowflakeTypesConverter.BytesToHex(new byte[] { b1, b2, b3 });
             Assert.AreEqual(hexExpected, hexResult);
         }
-
-        [Test]
-        [TestCase("0080ff", 0, 128, 255)]
-        [TestCase("0a0b0c", 10, 11, 12)]
-        public void ConvertHexToBytes(string hex, byte b1, byte b2, byte b3)
-        {
-            var expectedBytes = new byte[] { b1, b2, b3 };
-            var resultBytes = SnowflakeTypesConverter.HexToBytes(hex);
-
-            Assert.AreEqual(expectedBytes, resultBytes);
-        }
     }
 }

--- a/Snowflake.Client/Helpers/HexUtils.cs
+++ b/Snowflake.Client/Helpers/HexUtils.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Text;
+
+namespace Snowflake.Client.Helpers
+{
+    internal class HexUtils
+    {
+        const char __base64PaddingChar = '=';
+
+        // The base64 encoding table.
+        private static readonly char[] __base64Table =
+        {
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+            'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+            'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+            'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+        };
+
+        private static readonly int[] __hexValueTable = new int[256];
+
+        static HexUtils()
+        {
+            // Build hex character to value lookup table.
+            // Init all elements to -1 to begin with.
+            for(int i = 0; i < __hexValueTable.Length; i++)
+                __hexValueTable[i] = -1;
+            
+            // Set the mappings for the hex characters (upper and lower case).
+            for(char c = '0'; c <= '9'; c++) __hexValueTable[c] = c - '0';
+            for(char c = 'A'; c <= 'F'; c++) __hexValueTable[c] = c - 'A' + 10;
+            for(char c = 'a'; c <= 'f'; c++) __hexValueTable[c] = c - 'a' + 10;
+        }
+
+        public static void HexToBase64(string hex, StringBuilder sb)
+        {
+            if(hex.Length % 2 != 0)
+                throw new ArgumentException("The hexadecimal string cannot have an odd length.");
+
+            // Get a span over the inp0ut string, for fast/efficient processing of the characters.
+            ReadOnlySpan<char> hexSpan = hex.AsSpan();
+
+            // Allocate temp storage for decoded hex chars, and encoded base64 characters.
+            Span<byte> inBytes = stackalloc byte[3];
+            Span<char> outChars = stackalloc char[4];
+
+            // Loop over hexSpan in six character chunks (6 hex chars represents 3 bytes).
+            while(hexSpan.Length >= 6)
+            {
+                // Decode 6 hex chars to 3 bytes.
+                inBytes[0] = HexToByte(hexSpan);
+                inBytes[1] = HexToByte(hexSpan.Slice(2));
+                inBytes[2] = HexToByte(hexSpan.Slice(4));
+
+                // Encode the three bytes as a base64 block (3 bytes becomes 4 base64 characters).
+                EncodeBase64Block(inBytes, outChars);
+
+                // Write the base64 chars to the string builder.
+                sb.Append(outChars[0]);
+                sb.Append(outChars[1]);
+                sb.Append(outChars[2]);
+                sb.Append(outChars[3]);
+
+                // Move hexSpan forward six chars.
+                hexSpan = hexSpan.Slice(6);
+            }
+
+            // Handle any remaining hex chars / bytes. I.e., when hex.Length is not a multiple of 6.
+            switch(hexSpan.Length)
+            {
+                case 0:
+                    // No more hex chars; exit.
+                    break;
+
+                case 2:
+                    // Two hex chars remaining (i.e., one byte).
+                    inBytes[0] = HexToByte(hexSpan);
+                    inBytes[1] = 0;
+                    inBytes[2] = 0;
+                    EncodeBase64Block(inBytes, outChars);
+                    sb.Append(outChars[0]);
+                    sb.Append(outChars[1]);
+                    sb.Append(__base64PaddingChar);
+                    sb.Append(__base64PaddingChar);
+                    break;
+
+                case 4:
+                    // Four hex chars remaining (i.e., two bytes).
+                    inBytes[0] = HexToByte(hexSpan);
+                    inBytes[1] = HexToByte(hexSpan.Slice(2));
+                    inBytes[2] = 0;
+                    EncodeBase64Block(inBytes, outChars);
+                    sb.Append(outChars[0]);
+                    sb.Append(outChars[1]);
+                    sb.Append(outChars[2]);
+                    sb.Append(__base64PaddingChar);
+                    break;
+            }
+        }
+
+        private static byte HexToByte(ReadOnlySpan<char> hexSpan)
+        {
+            return (byte)(GetHexValue(hexSpan[0]) << 4 | GetHexValue(hexSpan[1]));
+        }
+
+        private static int GetHexValue(char hexCharacter)
+        {
+            if(hexCharacter > 255)
+                throw new ArgumentException("Invalid hexadecimal character.");
+
+            // Lookup the character's value.
+            int value = __hexValueTable[hexCharacter];
+
+            // If the value is -1 then the character is not a hexadecimal character.
+            if(value >= 0)
+                return value;
+
+            throw new ArgumentException("Invalid hexadecimal character.");
+        }
+
+        private static void EncodeBase64Block(ReadOnlySpan<byte> inBytes, Span<char> outChars)
+        {
+            // Encode and write the three bytes as a base64 block (3 bytes becomes 4 base64 characters).
+            outChars[0] = __base64Table[(inBytes[0] & 0xfc) >> 2];
+            outChars[1] = __base64Table[((inBytes[0] & 0x03) << 4) | ((inBytes[1] & 0xf0) >> 4)];
+            outChars[2] = __base64Table[((inBytes[1] & 0x0f) << 2) | ((inBytes[2] & 0xc0) >> 6)];
+            outChars[3] = __base64Table[inBytes[2] & 0x3f];
+        }
+    }
+}

--- a/Snowflake.Client/Helpers/HexUtils.cs
+++ b/Snowflake.Client/Helpers/HexUtils.cs
@@ -119,7 +119,7 @@ namespace Snowflake.Client.Helpers
 
         private static void EncodeBase64Block(ReadOnlySpan<byte> inBytes, Span<char> outChars)
         {
-            // Encode and write the three bytes as a base64 block (3 bytes becomes 4 base64 characters).
+            // Encode the three bytes as a base64 block (3 bytes becomes 4 base64 characters).
             outChars[0] = __base64Table[(inBytes[0] & 0xfc) >> 2];
             outChars[1] = __base64Table[((inBytes[0] & 0x03) << 4) | ((inBytes[1] & 0xf0) >> 4)];
             outChars[2] = __base64Table[((inBytes[1] & 0x0f) << 2) | ((inBytes[2] & 0xc0) >> 6)];

--- a/Snowflake.Client/Helpers/HexUtils.cs
+++ b/Snowflake.Client/Helpers/HexUtils.cs
@@ -36,7 +36,7 @@ namespace Snowflake.Client.Helpers
             if(hex.Length % 2 != 0)
                 throw new ArgumentException("The hexadecimal string cannot have an odd length.");
 
-            // Get a span over the inp0ut string, for fast/efficient processing of the characters.
+            // Get a span over the input string, for fast/efficient processing of the characters.
             ReadOnlySpan<char> hexSpan = hex.AsSpan();
 
             // Allocate temp storage for decoded hex chars, and encoded base64 characters.

--- a/Snowflake.Client/ObjectPool/CustomStringBuilderPooledObjectPolicy.cs
+++ b/Snowflake.Client/ObjectPool/CustomStringBuilderPooledObjectPolicy.cs
@@ -1,0 +1,43 @@
+﻿using System.Text;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Snowflake.Client.ObjectPool
+{
+    /// <summary>
+    /// A policy for pooling <see cref="StringBuilder"/> instances.
+    /// </summary>
+    internal class CustomStringBuilderPooledObjectPolicy : PooledObjectPolicy<StringBuilder>
+    {
+        /// <summary>
+        /// Gets or sets the initial capacity of pooled <see cref="StringBuilder"/> instances.
+        /// </summary>
+        /// <value>Defaults to <c>100</c>.</value>
+        public int InitialCapacity { get; set; } = 1024;
+
+        /// <summary>
+        /// Gets or sets the maximum value for <see cref="StringBuilder.Capacity"/> that is allowed to be
+        /// retained, when <see cref="Return(StringBuilder)"/> is invoked.
+        /// </summary>
+        /// <value>Defaults to <c>4096</c>.</value>
+        public int MaximumRetainedCapacity { get; set; } = 16 * 1024;
+
+        /// <inheritdoc />
+        public override StringBuilder Create()
+        {
+            return new StringBuilder(InitialCapacity);
+        }
+
+        /// <inheritdoc />
+        public override bool Return(StringBuilder obj)
+        {
+            if (obj.Capacity > MaximumRetainedCapacity)
+            {
+                // Too big. Discard this one.
+                return false;
+            }
+
+            obj.Clear();
+            return true;
+        }
+    }
+}

--- a/Snowflake.Client/Snowflake.Client.csproj
+++ b/Snowflake.Client/Snowflake.Client.csproj
@@ -18,7 +18,7 @@ Provides straightforward and efficient way to execute SQL queries in Snowflake a
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" Version="4.6.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Snowflake.Client/Snowflake.Client.csproj
+++ b/Snowflake.Client/Snowflake.Client.csproj
@@ -23,6 +23,7 @@ Provides straightforward and efficient way to execute SQL queries in Snowflake a
 
   <ItemGroup>
     <InternalsVisibleTo Include="Snowflake.Client.Tests" />
+    <InternalsVisibleTo Include="Snowflake.Client.Benchmarks" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Snowflake.Client/Snowflake.Client.csproj
+++ b/Snowflake.Client/Snowflake.Client.csproj
@@ -22,6 +22,10 @@ Provides straightforward and efficient way to execute SQL queries in Snowflake a
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Snowflake.Client.Tests" />
     <InternalsVisibleTo Include="Snowflake.Client.Benchmarks" />
   </ItemGroup>

--- a/Snowflake.Client/SnowflakeDataMapper.cs
+++ b/Snowflake.Client/SnowflakeDataMapper.cs
@@ -1,4 +1,5 @@
-﻿using Snowflake.Client.Json;
+﻿using Snowflake.Client.Helpers;
+using Snowflake.Client.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -147,10 +148,8 @@ namespace Snowflake.Client
                     break;
 
                 case "binary":
-                    var bytes = SnowflakeTypesConverter.HexToBytes(value);
-                    var base64 = Convert.ToBase64String(bytes);
                     sb.Append('"');
-                    sb.Append(base64);
+                    HexUtils.HexToBase64(value, sb);
                     sb.Append('"');
                     break;
 

--- a/Snowflake.Client/SnowflakeDataMapper.cs
+++ b/Snowflake.Client/SnowflakeDataMapper.cs
@@ -28,7 +28,10 @@ namespace Snowflake.Client
             if (column == null)
                 throw new ArgumentNullException(nameof(column));
 
-            var jsonToken = ConvertColumnValueToJsonToken(value, column.Type);
+            var sb = new StringBuilder(32);
+            ConvertColumnValueToJsonToken(value, column.Type, sb);
+            var jsonToken = sb.ToString();
+
             return JsonSerializer.Deserialize<T>(jsonToken, _jsonMapperOptions);
         }
 
@@ -89,15 +92,6 @@ namespace Snowflake.Client
 
             // Append json property value.
             ConvertColumnValueToJsonToken(columnValue, columnType, sb);
-        }
-
-        private static string ConvertColumnValueToJsonToken(
-            string value,
-            string columnType)
-        {
-            var sb = new StringBuilder();
-            ConvertColumnValueToJsonToken(value,columnType, sb);
-            return sb.ToString();
         }
 
         private static void ConvertColumnValueToJsonToken(

--- a/Snowflake.Client/SnowflakeTypesConverter.cs
+++ b/Snowflake.Client/SnowflakeTypesConverter.cs
@@ -80,17 +80,6 @@ namespace Snowflake.Client
             return hexBuilder.ToString();
         }
 
-        internal static byte[] HexToBytes(string hex)
-        {
-            var numberChars = hex.Length;
-            var bytes = new byte[numberChars / 2];
-
-            for (var i = 0; i < numberChars; i += 2)
-                bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
-
-            return bytes;
-        }
-
         private static Tuple<long, long> ExtractTimestamp(string srcVal)
         {
             var dotIndex = srcVal.IndexOf('.');

--- a/SnowflakeClient.sln
+++ b/SnowflakeClient.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.5.33627.172
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Client", "Snowflake.Client\Snowflake.Client.csproj", "{2D0DF1AE-9CF2-4D1E-9D05-C5063D2BB4C5}"
 EndProject

--- a/SnowflakeClient.sln
+++ b/SnowflakeClient.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30413.136
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33627.172
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Client", "Snowflake.Client\Snowflake.Client.csproj", "{2D0DF1AE-9CF2-4D1E-9D05-C5063D2BB4C5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Snowflake.Client.Tests", "Snowflake.Client.Tests\Snowflake.Client.Tests.csproj", "{B9B59C25-9601-4AFC-812E-8A9228CEBC2F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snowflake.Client.Tests", "Snowflake.Client.Tests\Snowflake.Client.Tests.csproj", "{B9B59C25-9601-4AFC-812E-8A9228CEBC2F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Snowflake.Client.Benchmarks", "Snowflake.Client.Benchmarks\Snowflake.Client.Benchmarks.csproj", "{C9F6FB48-6340-4407-A466-4545BA003C6C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{B9B59C25-9601-4AFC-812E-8A9228CEBC2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B9B59C25-9601-4AFC-812E-8A9228CEBC2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B9B59C25-9601-4AFC-812E-8A9228CEBC2F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9F6FB48-6340-4407-A466-4545BA003C6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9F6FB48-6340-4407-A466-4545BA003C6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9F6FB48-6340-4407-A466-4545BA003C6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9F6FB48-6340-4407-A466-4545BA003C6C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Use of StringBuilder to build the JSON strings that are passed to `JsonSerializer.Deserialize<T>()`; this reduces the number of strings allocated when doing string concatenation using the `+` operator. This is particularly beneficial when dealing with a large binary hex value, as the intermediate strings from each concatenation can be huge in that scenario.

Regarding handling of binary hex, the hex is now encoded to base64 and appended to the StringBuilder in one method call; this avoid an intermediate base64 string (which, again, can be very large).

None of this is perfect, as the final result is still one large JSON string, potentially with very large base64 strings in it, but this PR will reduce the amount of intermediate strings that are allocated.

I have also added a `Snowflake.Client.Benchmarks` project to demonstrate the improved performance of the hex to base64 conversion for large binary values (about 4x faster, and less memory allocations).

For information, there is another branch at https://github.com/colgreen/snowflake-db-net-client/tree/deserialization-efficiency-improvements-streams that takes this code further by using a utf8 `RecyclableMemoryStream` instead of `StringBuilder`; that means the base64 strings are half the size (because the base64 chars are encoded to single bytes instead of two bytes per character for .NET strings). Ultimately I decided not to create a PR for that code as it meant using `JsonSerializer.DeserializeAsync<T>()` instead of `JsonSerializer.Deserialize<T>()`, and that makes things more complex.  Really, to avoid excessive memory allocations when dealing with hex binary I think it would be better to not use JsonSerializer at all, and to use reflection to set the value on the target object directly, but I can see that using `JsonSerializer.Deserialize<T>()` is a very convenient approach that has all the nice features and flexibility of System.Text.Json deserialization, so this PR is basically making that a bit more efficient - in terms of reduced execution time and reduced memory allocations.
