### PR TITLE
Improve JSON serialization and deserialization

### DIFF
--- a/Snowflake.Client.Benchmarks/Snowflake.Client.Benchmarks.csproj
+++ b/Snowflake.Client.Benchmarks/Snowflake.Client.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/Snowflake.Client.Tests/Snowflake.Client.Tests.csproj
+++ b/Snowflake.Client.Tests/Snowflake.Client.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Copyright>Copyright (c) 2020-2021 Ilya Bystrov</Copyright>
   </PropertyGroup>

--- a/Snowflake.Client/RequestBuilder.cs
+++ b/Snowflake.Client/RequestBuilder.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Web;
@@ -24,17 +24,10 @@ namespace Snowflake.Client
         {
             _urlInfo = urlInfo;
             
-#if NETSTANDARD
-            _jsonSerializerOptions = new JsonSerializerOptions()
-            {
-                IgnoreNullValues = true
-            };
-#else
             _jsonSerializerOptions = new JsonSerializerOptions
             {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
-#endif
 
             _clientInfo = new ClientAppInfo();
         }
@@ -66,8 +59,7 @@ namespace Snowflake.Client
             };
 
             var requestBody = new LoginRequest() { Data = data };
-            var jsonBody = JsonSerializer.Serialize(requestBody, _jsonSerializerOptions);
-            var request = BuildJsonRequestMessage(requestUri, HttpMethod.Post, jsonBody);
+            var request = BuildJsonRequestMessage(requestUri, HttpMethod.Post, requestBody);
 
             return request;
         }
@@ -80,8 +72,7 @@ namespace Snowflake.Client
                 RequestId = requestId
             };
 
-            var jsonBody = JsonSerializer.Serialize(requestBody, _jsonSerializerOptions);
-            var request = BuildJsonRequestMessage(requestUri, HttpMethod.Post, jsonBody);
+            var request = BuildJsonRequestMessage(requestUri, HttpMethod.Post, requestBody);
 
             return request;
         }
@@ -95,8 +86,7 @@ namespace Snowflake.Client
                 RequestType = "RENEW"
             };
 
-            var jsonBody = JsonSerializer.Serialize(requestBody, _jsonSerializerOptions);
-            var request = BuildJsonRequestMessage(requestUri, HttpMethod.Post, jsonBody, true);
+            var request = BuildJsonRequestMessage(requestUri, HttpMethod.Post, requestBody, true);
 
             return request;
         }
@@ -112,8 +102,7 @@ namespace Snowflake.Client
                 Bindings = ParameterBinder.BuildParameterBindings(sqlParams)
             };
 
-            var jsonBody = JsonSerializer.Serialize(requestBody, _jsonSerializerOptions);
-            var request = BuildJsonRequestMessage(queryUri, HttpMethod.Post, jsonBody);
+            var request = BuildJsonRequestMessage(queryUri, HttpMethod.Post, requestBody);
 
             return request;
         }
@@ -212,15 +201,20 @@ namespace Snowflake.Client
             return uriBuilder.Uri;
         }
 
-        private HttpRequestMessage BuildJsonRequestMessage(Uri uri, HttpMethod method, string jsonBody = null, bool useMasterToken = false)
+        private HttpRequestMessage BuildJsonRequestMessage(Uri uri, HttpMethod method, bool useMasterToken = false)
+        {
+            return BuildJsonRequestMessage<object>(uri, method, null, useMasterToken);
+        }
+
+        private HttpRequestMessage BuildJsonRequestMessage<T>(Uri uri, HttpMethod method, T requestBody = default, bool useMasterToken = false)
         {
             var request = new HttpRequestMessage();
             request.Method = method;
             request.RequestUri = uri;
 
-            if (jsonBody != null && method != HttpMethod.Get)
+            if (requestBody != null && method != HttpMethod.Get)
             {
-                request.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+                request.Content = JsonContent.Create(requestBody, options: _jsonSerializerOptions);
             }
 
             if (_sessionToken != null)

--- a/Snowflake.Client/RestClient.cs
+++ b/Snowflake.Client/RestClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Security.Authentication;
 using System.Text.Json;
 using System.Threading;
@@ -44,14 +45,7 @@ namespace Snowflake.Client
             request.Headers.ExpectContinue = false;
             var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
-
-#if NETSTANDARD
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-#else
-            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-#endif
-            
-            return JsonSerializer.Deserialize<T>(json, _jsonSerializerOptions);
+            return await response.Content.ReadFromJsonAsync<T>(_jsonSerializerOptions, ct).ConfigureAwait(false);
         }
     }
 }

--- a/Snowflake.Client/Snowflake.Client.csproj
+++ b/Snowflake.Client/Snowflake.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.4.6</Version>
     <Authors>fixer_m</Authors>
@@ -18,7 +18,8 @@ Provides straightforward and efficient way to execute SQL queries in Snowflake a
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Use JsonContent.Create() for requests in order to avoid the intermediate string serialization.
* Use ReadFromJsonAsync<T>() for responses in order to avoid the intermediate string serialization.

Also update target framework from .NET 6 (unsupported) to .NET 8 (current LTS).
